### PR TITLE
Optimize memory usage on big files

### DIFF
--- a/Demo/Demo iOS/Base.lproj/Main.storyboard
+++ b/Demo/Demo iOS/Base.lproj/Main.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -19,14 +17,14 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="bjH-BI-yoS">
-                                <rect key="frame" x="100" y="50" width="175" height="175"/>
+                                <rect key="frame" x="100" y="30" width="175" height="175"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="175" id="DKq-cl-mmg"/>
                                     <constraint firstAttribute="height" constant="175" id="wJR-pg-qZe"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Album" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="v1M-6L-KFx">
-                                <rect key="frame" x="30" y="325" width="325" height="20"/>
+                                <rect key="frame" x="30" y="305" width="53.5" height="20"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="20" id="aBM-7h-qaX"/>
                                 </constraints>
@@ -35,7 +33,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Artist" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nw6-ux-c27">
-                                <rect key="frame" x="30" y="400" width="315" height="21"/>
+                                <rect key="frame" x="30" y="384" width="315" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="aCf-BZ-t6Y"/>
                                 </constraints>
@@ -44,16 +42,15 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Yed-jb-ZrO" userLabel="Title Text Field">
-                                <rect key="frame" x="30" y="275" width="315" height="30"/>
+                                <rect key="frame" x="30" y="255" width="315" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="30" id="BQB-xL-j6c"/>
                                 </constraints>
-                                <nil key="textColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jWM-mq-z68" userLabel="Title Label">
-                                <rect key="frame" x="30" y="250" width="315" height="20"/>
+                                <rect key="frame" x="30" y="230" width="315" height="20"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="20" id="mJf-LC-M58"/>
                                 </constraints>
@@ -62,81 +59,73 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="o7n-QT-uR9">
-                                <rect key="frame" x="30" y="350" width="100" height="30"/>
+                                <rect key="frame" x="30" y="330" width="100" height="34"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="100" id="W5g-pD-4ak"/>
                                 </constraints>
-                                <nil key="textColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="u8L-DN-cuP">
-                                <rect key="frame" x="30" y="426" width="315" height="30"/>
-                                <nil key="textColor"/>
+                                <rect key="frame" x="30" y="410" width="315" height="34"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CfK-yU-uI1">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CfK-yU-uI1">
                                 <rect key="frame" x="115" y="622" width="51" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Update"/>
                                 <connections>
                                     <action selector="update:" destination="BYZ-38-t0r" eventType="touchUpInside" id="BzM-H6-EL4"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WzQ-mF-dnW">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WzQ-mF-dnW">
                                 <rect key="frame" x="225" y="622" width="34" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Load"/>
                                 <connections>
                                     <action selector="load:" destination="BYZ-38-t0r" eventType="touchUpInside" id="xpI-b5-pRe"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Genre" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i5F-tC-m6X">
-                                <rect key="frame" x="30" y="476" width="50" height="21"/>
+                                <rect key="frame" x="30" y="464" width="50" height="21"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="iue-Lp-cTb">
-                                <rect key="frame" x="30" y="502" width="70" height="30"/>
+                                <rect key="frame" x="30" y="490" width="70" height="34"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="70" id="7py-Nz-6IV"/>
                                 </constraints>
-                                <nil key="textColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="M6R-xU-VcN">
-                                <rect key="frame" x="115" y="502" width="229" height="30"/>
-                                <nil key="textColor"/>
+                                <rect key="frame" x="115" y="490" width="229" height="34"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Year" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JB8-2k-Xmw">
-                                <rect key="frame" x="30" y="552" width="37" height="21"/>
+                                <rect key="frame" x="30" y="544" width="37" height="21"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3hC-zz-Y96">
-                                <rect key="frame" x="30" y="581" width="315" height="30"/>
-                                <nil key="textColor"/>
+                                <rect key="frame" x="30" y="573" width="315" height="34"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Album Artist" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="13T-6t-OkL">
-                                <rect key="frame" x="166" y="324" width="104" height="21"/>
+                                <rect key="frame" x="166" y="304" width="104" height="21"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="hxN-AM-9fi" userLabel="Album Artist Field">
-                                <rect key="frame" x="166" y="350" width="100" height="30"/>
+                                <rect key="frame" x="166" y="330" width="100" height="34"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="100" id="em0-da-uMu"/>
                                 </constraints>
-                                <nil key="textColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
@@ -154,28 +143,37 @@
                             <constraint firstItem="M6R-xU-VcN" firstAttribute="leading" secondItem="iue-Lp-cTb" secondAttribute="trailing" constant="15" id="JUO-Fw-dvF"/>
                             <constraint firstItem="iue-Lp-cTb" firstAttribute="top" secondItem="i5F-tC-m6X" secondAttribute="bottom" constant="5" id="LLO-nC-l9e"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="Yed-jb-ZrO" secondAttribute="trailing" constant="30" id="NWI-1K-uL4"/>
+                            <constraint firstItem="3hC-zz-Y96" firstAttribute="leading" secondItem="CfK-yU-uI1" secondAttribute="trailing" constant="-136" id="QA0-5Y-eWt"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="jWM-mq-z68" secondAttribute="trailing" constant="30" id="S6Z-4j-aDC"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="M6R-xU-VcN" secondAttribute="trailing" constant="31" id="ShX-zl-Fbe"/>
                             <constraint firstItem="i5F-tC-m6X" firstAttribute="top" secondItem="u8L-DN-cuP" secondAttribute="bottom" constant="20" id="Sox-gV-Oil"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="v1M-6L-KFx" secondAttribute="trailing" constant="20" id="U8r-zg-TG9"/>
+                            <constraint firstItem="CfK-yU-uI1" firstAttribute="top" secondItem="3hC-zz-Y96" secondAttribute="bottom" constant="15" id="U7B-0n-8qG"/>
                             <constraint firstItem="3hC-zz-Y96" firstAttribute="top" secondItem="JB8-2k-Xmw" secondAttribute="bottom" constant="8" id="UFm-so-Y7e"/>
                             <constraint firstItem="hxN-AM-9fi" firstAttribute="leading" secondItem="o7n-QT-uR9" secondAttribute="trailing" constant="36" id="UsS-wY-NKq"/>
                             <constraint firstItem="bjH-BI-yoS" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="30" id="VTp-eX-ozk"/>
                             <constraint firstItem="v1M-6L-KFx" firstAttribute="top" secondItem="Yed-jb-ZrO" secondAttribute="bottom" constant="20" id="W1i-fq-qxe"/>
                             <constraint firstItem="i5F-tC-m6X" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="30" id="XVz-O3-35F"/>
+                            <constraint firstItem="WzQ-mF-dnW" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="CfK-yU-uI1" secondAttribute="trailing" symbolic="YES" id="XZF-r9-Wx2"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="i5F-tC-m6X" secondAttribute="trailing" symbolic="YES" id="YBa-it-SG3"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="JB8-2k-Xmw" secondAttribute="trailing" symbolic="YES" id="b9P-2d-1xy"/>
                             <constraint firstItem="hxN-AM-9fi" firstAttribute="top" secondItem="13T-6t-OkL" secondAttribute="bottom" constant="5" id="c29-XX-SkK"/>
                             <constraint firstItem="jWM-mq-z68" firstAttribute="top" secondItem="bjH-BI-yoS" secondAttribute="bottom" constant="25" id="cEE-2r-ehw"/>
                             <constraint firstItem="Nw6-ux-c27" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="30" id="dvJ-xh-DG6"/>
-                            <constraint firstItem="13T-6t-OkL" firstAttribute="leading" secondItem="v1M-6L-KFx" secondAttribute="trailing" constant="-189" id="fqx-TZ-GSc"/>
+                            <constraint firstItem="13T-6t-OkL" firstAttribute="leading" secondItem="hxN-AM-9fi" secondAttribute="leading" id="fEI-vX-Nau"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="3hC-zz-Y96" secondAttribute="trailing" constant="30" id="hTm-vk-w2Q"/>
+                            <constraint firstItem="13T-6t-OkL" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="v1M-6L-KFx" secondAttribute="trailing" symbolic="YES" id="heG-Vh-LZb"/>
+                            <constraint firstItem="CfK-yU-uI1" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="115" id="kBp-CP-zRc"/>
                             <constraint firstItem="bjH-BI-yoS" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="kRK-VB-n8A"/>
                             <constraint firstItem="JB8-2k-Xmw" firstAttribute="top" secondItem="iue-Lp-cTb" secondAttribute="bottom" constant="20" id="l0e-tK-x6X"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="13T-6t-OkL" secondAttribute="trailing" constant="105" id="lKy-hB-Tml"/>
                             <constraint firstItem="o7n-QT-uR9" firstAttribute="top" secondItem="v1M-6L-KFx" secondAttribute="bottom" constant="5" id="nRa-yr-8Ux"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="WzQ-mF-dnW" secondAttribute="trailing" constant="116" id="oIh-Rm-kgx"/>
                             <constraint firstItem="3hC-zz-Y96" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="30" id="pVZ-62-kFn"/>
                             <constraint firstItem="M6R-xU-VcN" firstAttribute="top" secondItem="i5F-tC-m6X" secondAttribute="bottom" constant="5" id="qc5-k6-wmI"/>
                             <constraint firstItem="Yed-jb-ZrO" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="30" id="r4P-Nw-zOd"/>
                             <constraint firstItem="u8L-DN-cuP" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="30" id="rY1-sd-RFP"/>
                             <constraint firstItem="iue-Lp-cTb" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="30" id="s2X-Z1-2Vi"/>
+                            <constraint firstItem="WzQ-mF-dnW" firstAttribute="top" secondItem="3hC-zz-Y96" secondAttribute="bottom" constant="15" id="sE4-dn-sQL"/>
                             <constraint firstItem="13T-6t-OkL" firstAttribute="top" secondItem="Yed-jb-ZrO" secondAttribute="bottom" constant="19" id="uhN-qq-g3d"/>
                             <constraint firstItem="v1M-6L-KFx" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="30" id="wSP-2Q-X4p"/>
                         </constraints>

--- a/Demo/Demo iOS/Info.plist
+++ b/Demo/Demo iOS/Info.plist
@@ -41,5 +41,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>

--- a/Demo/Demo iOS/ViewController.swift
+++ b/Demo/Demo iOS/ViewController.swift
@@ -45,7 +45,20 @@ class ViewController: UIViewController, UITextFieldDelegate {
                     .TrackPosition: ID3FrameTrackPosition(position: 2, totalTracks: 9)
                 ]
             )
-            try id3TagEditor.write(tag: id3Tag, to: PathLoader().pathFor(name: "example", fileType: "mp3"))
+            let documentDirectory = try FileManager.default.url(
+                for: .documentDirectory,
+                in: .userDomainMask,
+                appropriateFor:nil,
+                create:false
+            )
+            let newPath = documentDirectory.appendingPathComponent("example.mp3").path
+            print(PathLoader().pathFor(name: "example", fileType: "mp3"))
+            print(newPath)
+            try id3TagEditor.write(
+                tag: id3Tag,
+                to: PathLoader().pathFor(name: "example", fileType: "mp3"),
+                andSaveTo: newPath
+            )
         } catch {
             print(error)
         }

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -976,7 +976,7 @@
 				INFOPLIST_FILE = "Demo iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "it.chicio.Demo-iOS";
+				PRODUCT_BUNDLE_IDENTIFIER = "it.chicio.Demo-iOS-1";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.0;
@@ -995,7 +995,7 @@
 				INFOPLIST_FILE = "Demo iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "it.chicio.Demo-iOS";
+				PRODUCT_BUNDLE_IDENTIFIER = "it.chicio.Demo-iOS-1";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.0;
@@ -1054,7 +1054,7 @@
 				DEVELOPMENT_TEAM = Y682K92RZU;
 				INFOPLIST_FILE = "Demo watchOS Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "it.chicio.Demo-iOS.watchkitapp.watchkitextension";
+				PRODUCT_BUNDLE_IDENTIFIER = "it.chicio.Demo-iOS-1.watchkitapp-1.watchkitextension";
 				PRODUCT_NAME = "${TARGET_NAME}";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
@@ -1073,7 +1073,7 @@
 				DEVELOPMENT_TEAM = Y682K92RZU;
 				INFOPLIST_FILE = "Demo watchOS Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "it.chicio.Demo-iOS.watchkitapp.watchkitextension";
+				PRODUCT_BUNDLE_IDENTIFIER = "it.chicio.Demo-iOS-1.watchkitapp-1.watchkitextension";
 				PRODUCT_NAME = "${TARGET_NAME}";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
@@ -1095,7 +1095,7 @@
 				IBSC_MODULE = Demo_watchOS_Extension;
 				INFOPLIST_FILE = "Demo watchOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "it.chicio.Demo-iOS.watchkitapp";
+				PRODUCT_BUNDLE_IDENTIFIER = "it.chicio.Demo-iOS-1.watchkitapp-1";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
@@ -1116,7 +1116,7 @@
 				IBSC_MODULE = Demo_watchOS_Extension;
 				INFOPLIST_FILE = "Demo watchOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "it.chicio.Demo-iOS.watchkitapp";
+				PRODUCT_BUNDLE_IDENTIFIER = "it.chicio.Demo-iOS-1.watchkitapp-1";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;

--- a/Source/Mp3/Mp3WithID3TagBuilder.swift
+++ b/Source/Mp3/Mp3WithID3TagBuilder.swift
@@ -17,13 +17,12 @@ class Mp3WithID3TagBuilder {
     }
 
     func build(mp3: Data, newId3Tag: ID3Tag, currentId3Tag: ID3Tag?) throws -> Data {
-        let tag = try id3TagCreator.create(id3Tag: newId3Tag)
         var tagSizeWithHeader = 0
         if let validCurrentId3Tag = currentId3Tag {
             tagSizeWithHeader = Int(validCurrentId3Tag.properties.size) + ID3TagConfiguration().headerSize();
         }
-        let music = mp3.subdata(in: tagSizeWithHeader..<mp3.count)
-        let mp3WithTag = tag + music
+        var mp3WithTag = try id3TagCreator.create(id3Tag: newId3Tag)
+        mp3WithTag.append(mp3.subdata(in: tagSizeWithHeader..<mp3.count))
         return mp3WithTag
     }
 }


### PR DESCRIPTION
*Provide a general summary of your changes*
Try to avoid too much memory allocation for big files

## Description
This PR tries to fix the general memory usage of ID3TagEditor when it is writing new data to an mp3 file. A small PR that let ID3TagEditor save 1/3 of its memory usage by removing useless variable added only for "clean code" readability reasons. 

## Motivation and Context
When a ID3TagEditor library user tries to edit an large mp3 file (hundreds of MB) there was a big memory usage due to the fact that there were 3 instances (or big section of it) of type Data of the mp3 alive at the same time.

## How Has This Been Tested?
Tested on a iPhone 7 Plus (device with lowest capabilities at home 😂)

## Types of changes
- [X] Bug fix :bug: (non-breaking change which fixes an issue)
- [ ] New feature :sparkles: (non-breaking change which adds functionality)
- [ ] Breaking change :boom: (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/ID3TagEditor/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [X] I have added tests to cover my changes :tada:.
- [X] All new and existing tests passed :white_check_mark:.
