### PR TITLE
Added hashable, equatable and CaseIterable capabilities to all public enum API

### DIFF
--- a/Demo/Demo iOS/Base.lproj/Main.storyboard
+++ b/Demo/Demo iOS/Base.lproj/Main.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -16,168 +17,189 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="bjH-BI-yoS">
-                                <rect key="frame" x="100" y="30" width="175" height="175"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Mdx-ej-Dji">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <subviews>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="u8L-DN-cuP">
+                                        <rect key="frame" x="122" y="245" width="245" height="34"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Album" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="v1M-6L-KFx">
+                                        <rect key="frame" x="18" y="294" width="96" height="20"/>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Artist" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nw6-ux-c27">
+                                        <rect key="frame" x="18" y="252" width="96" height="18"/>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WzQ-mF-dnW">
+                                        <rect key="frame" x="222" y="18" width="132" height="30"/>
+                                        <color key="backgroundColor" systemColor="labelColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="30" id="sT4-k1-2y4"/>
+                                        </constraints>
+                                        <state key="normal" title="Load"/>
+                                        <connections>
+                                            <action selector="load:" destination="BYZ-38-t0r" eventType="touchUpInside" id="xpI-b5-pRe"/>
+                                        </connections>
+                                    </button>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Genre" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i5F-tC-m6X">
+                                        <rect key="frame" x="18" y="421" width="96" height="18"/>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="o7n-QT-uR9">
+                                        <rect key="frame" x="122" y="287" width="244" height="34"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="iue-Lp-cTb">
+                                        <rect key="frame" x="122" y="413" width="70" height="34"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="70" id="bIS-6s-Ohm"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Year" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JB8-2k-Xmw">
+                                        <rect key="frame" x="18" y="379" width="96" height="18"/>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3hC-zz-Y96">
+                                        <rect key="frame" x="122" y="371" width="244" height="34"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="hxN-AM-9fi" userLabel="Album Artist Field">
+                                        <rect key="frame" x="122" y="329" width="244" height="34"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="bjH-BI-yoS">
+                                        <rect key="frame" x="17" y="18" width="175" height="175"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="175" id="Fmy-PZ-Ecc"/>
+                                            <constraint firstAttribute="width" constant="175" id="X0D-27-SWK"/>
+                                        </constraints>
+                                    </imageView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jWM-mq-z68" userLabel="Title Label">
+                                        <rect key="frame" x="18" y="212" width="96" height="20"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="20" id="owx-Fv-NGn"/>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="96" id="xUn-97-YTB"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CfK-yU-uI1">
+                                        <rect key="frame" x="222" y="56" width="132" height="30"/>
+                                        <color key="backgroundColor" systemColor="labelColor"/>
+                                        <state key="normal" title="Update"/>
+                                        <connections>
+                                            <action selector="update:" destination="BYZ-38-t0r" eventType="touchUpInside" id="BzM-H6-EL4"/>
+                                        </connections>
+                                    </button>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Yed-jb-ZrO" userLabel="Title Text Field">
+                                        <rect key="frame" x="122" y="207" width="245" height="30"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="30" id="XBL-fh-dpk"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="M6R-xU-VcN">
+                                        <rect key="frame" x="200" y="413" width="167" height="34"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Album Artist" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="13T-6t-OkL">
+                                        <rect key="frame" x="18" y="336" width="96" height="21"/>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="175" id="DKq-cl-mmg"/>
-                                    <constraint firstAttribute="height" constant="175" id="wJR-pg-qZe"/>
+                                    <constraint firstItem="o7n-QT-uR9" firstAttribute="height" secondItem="Yed-jb-ZrO" secondAttribute="height" multiplier="1.13333" id="0SG-Kc-s1S"/>
+                                    <constraint firstItem="JB8-2k-Xmw" firstAttribute="leading" secondItem="13T-6t-OkL" secondAttribute="leading" id="0aI-w9-L9Z"/>
+                                    <constraint firstItem="JB8-2k-Xmw" firstAttribute="height" secondItem="13T-6t-OkL" secondAttribute="height" multiplier="0.857143" id="1Td-1Q-y8G"/>
+                                    <constraint firstItem="i5F-tC-m6X" firstAttribute="trailing" secondItem="JB8-2k-Xmw" secondAttribute="trailing" id="1eW-IJ-zQB"/>
+                                    <constraint firstItem="jWM-mq-z68" firstAttribute="leading" secondItem="Mdx-ej-Dji" secondAttribute="leading" constant="18" id="20D-BR-Q3P"/>
+                                    <constraint firstItem="CfK-yU-uI1" firstAttribute="height" secondItem="WzQ-mF-dnW" secondAttribute="height" id="3iE-a0-PLm"/>
+                                    <constraint firstItem="3hC-zz-Y96" firstAttribute="height" secondItem="Yed-jb-ZrO" secondAttribute="height" multiplier="1.13333" id="3vl-pY-hpT"/>
+                                    <constraint firstItem="Nw6-ux-c27" firstAttribute="top" secondItem="jWM-mq-z68" secondAttribute="bottom" constant="20" id="3zL-hH-hAH"/>
+                                    <constraint firstAttribute="bottom" secondItem="CfK-yU-uI1" secondAttribute="bottom" constant="581" id="AHR-B1-t8J"/>
+                                    <constraint firstItem="u8L-DN-cuP" firstAttribute="leading" secondItem="Nw6-ux-c27" secondAttribute="trailing" constant="8" symbolic="YES" id="APi-2G-VYY"/>
+                                    <constraint firstItem="u8L-DN-cuP" firstAttribute="top" secondItem="Yed-jb-ZrO" secondAttribute="bottom" constant="8" symbolic="YES" id="CFU-W0-EeK"/>
+                                    <constraint firstItem="u8L-DN-cuP" firstAttribute="height" secondItem="Yed-jb-ZrO" secondAttribute="height" multiplier="1.13333" id="Ccp-dH-hW5"/>
+                                    <constraint firstItem="3hC-zz-Y96" firstAttribute="width" secondItem="Yed-jb-ZrO" secondAttribute="width" multiplier="0.995918" id="CdR-DG-dC8"/>
+                                    <constraint firstItem="M6R-xU-VcN" firstAttribute="leading" secondItem="iue-Lp-cTb" secondAttribute="trailing" constant="8" symbolic="YES" id="EAq-BE-eZu"/>
+                                    <constraint firstItem="i5F-tC-m6X" firstAttribute="height" secondItem="JB8-2k-Xmw" secondAttribute="height" id="KvL-FS-Sf2"/>
+                                    <constraint firstItem="M6R-xU-VcN" firstAttribute="trailing" secondItem="Yed-jb-ZrO" secondAttribute="trailing" id="MD8-Kt-nhY"/>
+                                    <constraint firstItem="iue-Lp-cTb" firstAttribute="top" secondItem="3hC-zz-Y96" secondAttribute="bottom" constant="8" symbolic="YES" id="MOg-9b-PrG"/>
+                                    <constraint firstItem="Nw6-ux-c27" firstAttribute="trailing" secondItem="jWM-mq-z68" secondAttribute="trailing" id="Mex-ed-qKV"/>
+                                    <constraint firstItem="13T-6t-OkL" firstAttribute="trailing" secondItem="v1M-6L-KFx" secondAttribute="trailing" id="NJg-JM-Vbg"/>
+                                    <constraint firstAttribute="trailing" secondItem="Yed-jb-ZrO" secondAttribute="trailing" constant="8" id="PrS-gu-gzk"/>
+                                    <constraint firstItem="jWM-mq-z68" firstAttribute="top" secondItem="bjH-BI-yoS" secondAttribute="bottom" constant="19" id="Rm8-jQ-hBW"/>
+                                    <constraint firstItem="u8L-DN-cuP" firstAttribute="width" secondItem="Yed-jb-ZrO" secondAttribute="width" id="RmL-K5-REx"/>
+                                    <constraint firstItem="JB8-2k-Xmw" firstAttribute="top" secondItem="13T-6t-OkL" secondAttribute="bottom" constant="22" id="U6L-8F-LmO"/>
+                                    <constraint firstItem="CfK-yU-uI1" firstAttribute="leading" secondItem="WzQ-mF-dnW" secondAttribute="leading" id="WBm-NZ-YGH"/>
+                                    <constraint firstItem="iue-Lp-cTb" firstAttribute="leading" secondItem="i5F-tC-m6X" secondAttribute="trailing" constant="8" symbolic="YES" id="XQT-K1-23x"/>
+                                    <constraint firstItem="13T-6t-OkL" firstAttribute="leading" secondItem="v1M-6L-KFx" secondAttribute="leading" id="YEX-Nc-GXH"/>
+                                    <constraint firstItem="v1M-6L-KFx" firstAttribute="leading" secondItem="Nw6-ux-c27" secondAttribute="leading" id="YNI-83-tTp"/>
+                                    <constraint firstItem="CfK-yU-uI1" firstAttribute="width" secondItem="WzQ-mF-dnW" secondAttribute="width" id="Z6X-3v-2kQ"/>
+                                    <constraint firstItem="Nw6-ux-c27" firstAttribute="leading" secondItem="jWM-mq-z68" secondAttribute="leading" id="a8p-RV-ZEw"/>
+                                    <constraint firstItem="O1A-ft-pzK" firstAttribute="trailing" secondItem="CfK-yU-uI1" secondAttribute="trailing" constant="21" id="ab5-N6-o66"/>
+                                    <constraint firstItem="13T-6t-OkL" firstAttribute="height" secondItem="v1M-6L-KFx" secondAttribute="height" multiplier="1.05" id="b5U-jH-561"/>
+                                    <constraint firstItem="Yed-jb-ZrO" firstAttribute="leading" secondItem="jWM-mq-z68" secondAttribute="trailing" constant="8" symbolic="YES" id="bEh-d9-lb6"/>
+                                    <constraint firstItem="CfK-yU-uI1" firstAttribute="top" secondItem="WzQ-mF-dnW" secondAttribute="bottom" constant="8" symbolic="YES" id="f3h-lB-XBN"/>
+                                    <constraint firstItem="3hC-zz-Y96" firstAttribute="top" secondItem="hxN-AM-9fi" secondAttribute="bottom" constant="8" symbolic="YES" id="fQK-qp-Dqo"/>
+                                    <constraint firstItem="M6R-xU-VcN" firstAttribute="centerY" secondItem="iue-Lp-cTb" secondAttribute="centerY" id="gB1-0c-aur"/>
+                                    <constraint firstItem="WzQ-mF-dnW" firstAttribute="leading" secondItem="bjH-BI-yoS" secondAttribute="trailing" constant="30" id="gC1-gn-Euf"/>
+                                    <constraint firstItem="o7n-QT-uR9" firstAttribute="width" secondItem="Yed-jb-ZrO" secondAttribute="width" multiplier="0.995918" id="gKL-Zk-erk"/>
+                                    <constraint firstItem="3hC-zz-Y96" firstAttribute="leading" secondItem="JB8-2k-Xmw" secondAttribute="trailing" constant="8" symbolic="YES" id="gM2-w8-SJA"/>
+                                    <constraint firstItem="v1M-6L-KFx" firstAttribute="trailing" secondItem="Nw6-ux-c27" secondAttribute="trailing" id="gmI-5o-q0q"/>
+                                    <constraint firstItem="i5F-tC-m6X" firstAttribute="top" secondItem="JB8-2k-Xmw" secondAttribute="bottom" constant="24" id="h6E-gl-u21"/>
+                                    <constraint firstItem="WzQ-mF-dnW" firstAttribute="top" secondItem="Mdx-ej-Dji" secondAttribute="top" constant="18" id="hW3-2M-m3i"/>
+                                    <constraint firstItem="hxN-AM-9fi" firstAttribute="top" secondItem="o7n-QT-uR9" secondAttribute="bottom" constant="8" symbolic="YES" id="hmC-5B-pXi"/>
+                                    <constraint firstItem="v1M-6L-KFx" firstAttribute="top" secondItem="Nw6-ux-c27" secondAttribute="bottom" constant="24" id="jqy-sk-PO5"/>
+                                    <constraint firstItem="o7n-QT-uR9" firstAttribute="leading" secondItem="v1M-6L-KFx" secondAttribute="trailing" constant="8" symbolic="YES" id="jyZ-KH-daw"/>
+                                    <constraint firstItem="i5F-tC-m6X" firstAttribute="leading" secondItem="JB8-2k-Xmw" secondAttribute="leading" id="kzh-Ds-gSM"/>
+                                    <constraint firstItem="13T-6t-OkL" firstAttribute="top" secondItem="v1M-6L-KFx" secondAttribute="bottom" constant="22" id="okP-hr-nOs"/>
+                                    <constraint firstItem="o7n-QT-uR9" firstAttribute="top" secondItem="u8L-DN-cuP" secondAttribute="bottom" constant="8" symbolic="YES" id="p3V-8w-S8O"/>
+                                    <constraint firstItem="v1M-6L-KFx" firstAttribute="height" secondItem="Nw6-ux-c27" secondAttribute="height" multiplier="1.11111" id="pMC-xI-lXW"/>
+                                    <constraint firstItem="hxN-AM-9fi" firstAttribute="height" secondItem="Yed-jb-ZrO" secondAttribute="height" multiplier="1.13333" id="rkW-22-5RD"/>
+                                    <constraint firstAttribute="trailing" secondItem="WzQ-mF-dnW" secondAttribute="trailing" constant="21" id="uHl-M6-XPt"/>
+                                    <constraint firstItem="JB8-2k-Xmw" firstAttribute="trailing" secondItem="13T-6t-OkL" secondAttribute="trailing" id="uic-Fl-QmX"/>
+                                    <constraint firstItem="bjH-BI-yoS" firstAttribute="leading" secondItem="Mdx-ej-Dji" secondAttribute="leading" constant="17" id="vFc-lu-6vH"/>
+                                    <constraint firstItem="Yed-jb-ZrO" firstAttribute="centerY" secondItem="jWM-mq-z68" secondAttribute="centerY" id="wdy-MY-FOk"/>
+                                    <constraint firstItem="hxN-AM-9fi" firstAttribute="width" secondItem="Yed-jb-ZrO" secondAttribute="width" multiplier="0.995918" id="xIf-x1-IAY"/>
+                                    <constraint firstItem="hxN-AM-9fi" firstAttribute="leading" secondItem="13T-6t-OkL" secondAttribute="trailing" constant="8" symbolic="YES" id="zR3-c5-dc6"/>
+                                    <constraint firstItem="bjH-BI-yoS" firstAttribute="top" secondItem="Mdx-ej-Dji" secondAttribute="top" constant="18" id="zym-8c-jwa"/>
                                 </constraints>
-                            </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Album" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="v1M-6L-KFx">
-                                <rect key="frame" x="30" y="305" width="53.5" height="20"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="20" id="aBM-7h-qaX"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Artist" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nw6-ux-c27">
-                                <rect key="frame" x="30" y="384" width="315" height="21"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="21" id="aCf-BZ-t6Y"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Yed-jb-ZrO" userLabel="Title Text Field">
-                                <rect key="frame" x="30" y="255" width="315" height="30"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="30" id="BQB-xL-j6c"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jWM-mq-z68" userLabel="Title Label">
-                                <rect key="frame" x="30" y="230" width="315" height="20"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="20" id="mJf-LC-M58"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="o7n-QT-uR9">
-                                <rect key="frame" x="30" y="330" width="100" height="34"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="100" id="W5g-pD-4ak"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="u8L-DN-cuP">
-                                <rect key="frame" x="30" y="410" width="315" height="34"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CfK-yU-uI1">
-                                <rect key="frame" x="115" y="622" width="51" height="30"/>
-                                <state key="normal" title="Update"/>
-                                <connections>
-                                    <action selector="update:" destination="BYZ-38-t0r" eventType="touchUpInside" id="BzM-H6-EL4"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WzQ-mF-dnW">
-                                <rect key="frame" x="225" y="622" width="34" height="30"/>
-                                <state key="normal" title="Load"/>
-                                <connections>
-                                    <action selector="load:" destination="BYZ-38-t0r" eventType="touchUpInside" id="xpI-b5-pRe"/>
-                                </connections>
-                            </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Genre" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i5F-tC-m6X">
-                                <rect key="frame" x="30" y="464" width="50" height="21"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="iue-Lp-cTb">
-                                <rect key="frame" x="30" y="490" width="70" height="34"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="70" id="7py-Nz-6IV"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="M6R-xU-VcN">
-                                <rect key="frame" x="115" y="490" width="229" height="34"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Year" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JB8-2k-Xmw">
-                                <rect key="frame" x="30" y="544" width="37" height="21"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3hC-zz-Y96">
-                                <rect key="frame" x="30" y="573" width="315" height="34"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Album Artist" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="13T-6t-OkL">
-                                <rect key="frame" x="166" y="304" width="104" height="21"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="hxN-AM-9fi" userLabel="Album Artist Field">
-                                <rect key="frame" x="166" y="330" width="100" height="34"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="100" id="em0-da-uMu"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
+                                <viewLayoutGuide key="contentLayoutGuide" id="Qbf-Zr-8gi"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="O1A-ft-pzK"/>
+                            </scrollView>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="jWM-mq-z68" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="30" id="1Zj-BI-yTI"/>
-                            <constraint firstItem="o7n-QT-uR9" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="30" id="2I5-CZ-Wxr"/>
-                            <constraint firstItem="JB8-2k-Xmw" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="30" id="39M-rL-PtM"/>
-                            <constraint firstItem="Nw6-ux-c27" firstAttribute="top" secondItem="o7n-QT-uR9" secondAttribute="bottom" constant="20" id="98x-wr-4A7"/>
-                            <constraint firstItem="Yed-jb-ZrO" firstAttribute="top" secondItem="jWM-mq-z68" secondAttribute="bottom" constant="5" id="DH6-MH-bFY"/>
-                            <constraint firstItem="u8L-DN-cuP" firstAttribute="top" secondItem="Nw6-ux-c27" secondAttribute="bottom" constant="5" id="E3z-WK-xtv"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="u8L-DN-cuP" secondAttribute="trailing" constant="30" id="E8T-Tc-nPu"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="Nw6-ux-c27" secondAttribute="trailing" constant="30" id="IOu-Ji-5Ev"/>
-                            <constraint firstItem="M6R-xU-VcN" firstAttribute="leading" secondItem="iue-Lp-cTb" secondAttribute="trailing" constant="15" id="JUO-Fw-dvF"/>
-                            <constraint firstItem="iue-Lp-cTb" firstAttribute="top" secondItem="i5F-tC-m6X" secondAttribute="bottom" constant="5" id="LLO-nC-l9e"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="Yed-jb-ZrO" secondAttribute="trailing" constant="30" id="NWI-1K-uL4"/>
-                            <constraint firstItem="3hC-zz-Y96" firstAttribute="leading" secondItem="CfK-yU-uI1" secondAttribute="trailing" constant="-136" id="QA0-5Y-eWt"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="jWM-mq-z68" secondAttribute="trailing" constant="30" id="S6Z-4j-aDC"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="M6R-xU-VcN" secondAttribute="trailing" constant="31" id="ShX-zl-Fbe"/>
-                            <constraint firstItem="i5F-tC-m6X" firstAttribute="top" secondItem="u8L-DN-cuP" secondAttribute="bottom" constant="20" id="Sox-gV-Oil"/>
-                            <constraint firstItem="CfK-yU-uI1" firstAttribute="top" secondItem="3hC-zz-Y96" secondAttribute="bottom" constant="15" id="U7B-0n-8qG"/>
-                            <constraint firstItem="3hC-zz-Y96" firstAttribute="top" secondItem="JB8-2k-Xmw" secondAttribute="bottom" constant="8" id="UFm-so-Y7e"/>
-                            <constraint firstItem="hxN-AM-9fi" firstAttribute="leading" secondItem="o7n-QT-uR9" secondAttribute="trailing" constant="36" id="UsS-wY-NKq"/>
-                            <constraint firstItem="bjH-BI-yoS" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="30" id="VTp-eX-ozk"/>
-                            <constraint firstItem="v1M-6L-KFx" firstAttribute="top" secondItem="Yed-jb-ZrO" secondAttribute="bottom" constant="20" id="W1i-fq-qxe"/>
-                            <constraint firstItem="i5F-tC-m6X" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="30" id="XVz-O3-35F"/>
-                            <constraint firstItem="WzQ-mF-dnW" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="CfK-yU-uI1" secondAttribute="trailing" symbolic="YES" id="XZF-r9-Wx2"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="i5F-tC-m6X" secondAttribute="trailing" symbolic="YES" id="YBa-it-SG3"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="JB8-2k-Xmw" secondAttribute="trailing" symbolic="YES" id="b9P-2d-1xy"/>
-                            <constraint firstItem="hxN-AM-9fi" firstAttribute="top" secondItem="13T-6t-OkL" secondAttribute="bottom" constant="5" id="c29-XX-SkK"/>
-                            <constraint firstItem="jWM-mq-z68" firstAttribute="top" secondItem="bjH-BI-yoS" secondAttribute="bottom" constant="25" id="cEE-2r-ehw"/>
-                            <constraint firstItem="Nw6-ux-c27" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="30" id="dvJ-xh-DG6"/>
-                            <constraint firstItem="13T-6t-OkL" firstAttribute="leading" secondItem="hxN-AM-9fi" secondAttribute="leading" id="fEI-vX-Nau"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="3hC-zz-Y96" secondAttribute="trailing" constant="30" id="hTm-vk-w2Q"/>
-                            <constraint firstItem="13T-6t-OkL" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="v1M-6L-KFx" secondAttribute="trailing" symbolic="YES" id="heG-Vh-LZb"/>
-                            <constraint firstItem="CfK-yU-uI1" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="115" id="kBp-CP-zRc"/>
-                            <constraint firstItem="bjH-BI-yoS" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="kRK-VB-n8A"/>
-                            <constraint firstItem="JB8-2k-Xmw" firstAttribute="top" secondItem="iue-Lp-cTb" secondAttribute="bottom" constant="20" id="l0e-tK-x6X"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="13T-6t-OkL" secondAttribute="trailing" constant="105" id="lKy-hB-Tml"/>
-                            <constraint firstItem="o7n-QT-uR9" firstAttribute="top" secondItem="v1M-6L-KFx" secondAttribute="bottom" constant="5" id="nRa-yr-8Ux"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="WzQ-mF-dnW" secondAttribute="trailing" constant="116" id="oIh-Rm-kgx"/>
-                            <constraint firstItem="3hC-zz-Y96" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="30" id="pVZ-62-kFn"/>
-                            <constraint firstItem="M6R-xU-VcN" firstAttribute="top" secondItem="i5F-tC-m6X" secondAttribute="bottom" constant="5" id="qc5-k6-wmI"/>
-                            <constraint firstItem="Yed-jb-ZrO" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="30" id="r4P-Nw-zOd"/>
-                            <constraint firstItem="u8L-DN-cuP" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="30" id="rY1-sd-RFP"/>
-                            <constraint firstItem="iue-Lp-cTb" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="30" id="s2X-Z1-2Vi"/>
-                            <constraint firstItem="WzQ-mF-dnW" firstAttribute="top" secondItem="3hC-zz-Y96" secondAttribute="bottom" constant="15" id="sE4-dn-sQL"/>
-                            <constraint firstItem="13T-6t-OkL" firstAttribute="top" secondItem="Yed-jb-ZrO" secondAttribute="bottom" constant="19" id="uhN-qq-g3d"/>
-                            <constraint firstItem="v1M-6L-KFx" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="30" id="wSP-2Q-X4p"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="Mdx-ej-Dji" secondAttribute="trailing" id="4ya-N4-56C"/>
+                            <constraint firstItem="Mdx-ej-Dji" firstAttribute="centerY" secondItem="6Tk-OE-BBY" secondAttribute="centerY" id="TzH-HI-9B4"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="Mdx-ej-Dji" secondAttribute="bottom" id="kIg-FG-uB9"/>
+                            <constraint firstItem="Mdx-ej-Dji" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="mYI-1U-q9Y"/>
+                            <constraint firstItem="Mdx-ej-Dji" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="oS8-Vm-TGc"/>
+                            <constraint firstItem="Mdx-ej-Dji" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="zES-6J-XYI"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                     <connections>
                         <outlet property="albumArtistField" destination="hxN-AM-9fi" id="Ebe-rl-zzS"/>
@@ -195,4 +217,9 @@
             <point key="canvasLocation" x="140" y="132.68365817091455"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Source/Frame/FrameName.swift
+++ b/Source/Frame/FrameName.swift
@@ -10,7 +10,64 @@ import Foundation
 
 /// An enum used to identify the different types of frame parsed by the ID3TagEditor. This must be used to acces the frame data as identifier inside the dictionary
 /// of frame in the `ID3tag` `frames` properties.
-public enum FrameName: Hashable {
+public enum FrameName: Equatable, Hashable, CaseIterable {
+    public static var allCases: [FrameName] {
+        return [
+            .Title,
+            .Album,
+            .AlbumArtist,
+            .Artist,
+            .Composer,
+            .Conductor,
+            .ContentGrouping,
+            .Copyright,
+            .EncodedBy,
+            .EncoderSettings,
+            .FileOwner,
+            .Lyricist,
+            .MixArtist,
+            .Publisher,
+            .Subtitle,
+            .Genre,
+            .DiscPosition,
+            .TrackPosition,
+            .RecordingDayMonth,
+            .RecordingYear,
+            .RecordingHourMinute,
+            .RecordingDateTime,
+            .AttachedPicture(.Other),
+            .AttachedPicture(.Other),
+            .AttachedPicture(.fileIcon),
+            .AttachedPicture(.OtherFileIcon),
+            .AttachedPicture(.FrontCover),
+            .AttachedPicture(.BackCover),
+            .AttachedPicture(.LeafletPage),
+            .AttachedPicture(.Media),
+            .AttachedPicture(.LeadArtistLeadPerformerSoloist),
+            .AttachedPicture(.ArtistPerformer),
+            .AttachedPicture(.Conductor),
+            .AttachedPicture(.BandOrchestra),
+            .AttachedPicture(.Composer),
+            .AttachedPicture(.LyricistTextWriter),
+            .AttachedPicture(.RecordingLocation),
+            .AttachedPicture(.DuringRecording),
+            .AttachedPicture(.DuringPerformance),
+            .AttachedPicture(.MovieVideoScreenCapture),
+            .AttachedPicture(.ABrightColouredFish),
+            .AttachedPicture(.Illustration),
+            .AttachedPicture(.BandArtistLogotype),
+            .AttachedPicture(.PublisherStudioLogotype),
+            .iTunesGrouping,
+            .iTunesMovementName,
+            .iTunesMovementIndex,
+            .iTunesMovementCount,
+            .iTunesPodcastCategory,
+            .iTunesPodcastDescription,
+            .iTunesPodcastID,
+            .iTunesPodcastKeywords
+        ]
+    }
+    
     /// Title frame name.
     case Title
     /// Album frame name.

--- a/Source/Frame/ID3Genre.swift
+++ b/Source/Frame/ID3Genre.swift
@@ -10,7 +10,7 @@ import Foundation
 /**
  An enum that contains the genres supported by the ID3 standard using specific identifiers.
  */
-public enum ID3Genre: Int, Equatable {
+public enum ID3Genre: Int, Equatable, Hashable, CaseIterable {
     /// Blues genre.
     case Blues = 0
     /// Classic rock genre.

--- a/Source/Frame/ID3Genre.swift
+++ b/Source/Frame/ID3Genre.swift
@@ -175,16 +175,4 @@ public enum ID3Genre: Int, Equatable, Hashable, CaseIterable {
     case Remix = 80
     /// Cover genre.
     case Cover = 81
-
-    /**
-     Compare two ID3Genre.
-
-     - parameter lhs: left side of compare operation.
-     - parameter rhs: right side of compare operation.
-
-     - returns: true if the genre values are the same, else false.
-     */
-    public static func ==(lhs: ID3Genre, rhs: ID3Genre) -> Bool {
-        return lhs.rawValue == rhs.rawValue
-    }
 }

--- a/Source/Frame/ID3PictureFormat.swift
+++ b/Source/Frame/ID3PictureFormat.swift
@@ -10,7 +10,7 @@ import Foundation
 /**
  The attached picture format supported by the ID3 tag.
  */
-public enum ID3PictureFormat {
+public enum ID3PictureFormat: Equatable, Hashable, CaseIterable  {
     /// Jpeg image.
     case Jpeg
     /// Png image.

--- a/Source/Frame/ID3PictureType.swift
+++ b/Source/Frame/ID3PictureType.swift
@@ -10,7 +10,7 @@ import Foundation
 /**
  An enum that describes the ID3 picture type supported.
  */
-public enum ID3PictureType: UInt8, Equatable, CaseIterable {
+public enum ID3PictureType: UInt8, Equatable, Hashable, CaseIterable {
     /// Other image.
     case Other = 0x00
     /// File icon image.
@@ -53,16 +53,4 @@ public enum ID3PictureType: UInt8, Equatable, CaseIterable {
     case BandArtistLogotype = 0x13
     /// Publisher logo image.
     case PublisherStudioLogotype = 0x14
-
-    /**
-     Compare two ID3PictureType.
-
-     - parameter lhs: left side of compare operation.
-     - parameter rhs: right side of compare operation.
-
-     - returns: true if the picture types are the same, else false.
-     */
-    public static func ==(lhs: ID3PictureType, rhs: ID3PictureType) -> Bool {
-        return lhs.rawValue == rhs.rawValue
-    }
 }

--- a/Source/ID3Version.swift
+++ b/Source/ID3Version.swift
@@ -10,7 +10,7 @@ import Foundation
 /**
  Enum that contains the version supported by ID3TagEditor.
  */
-public enum ID3Version: UInt8, Comparable {
+public enum ID3Version: UInt8, Comparable, Equatable, Hashable, CaseIterable {
     /// ID3 2.2 version.
     case version2 = 2
     /// ID3 2.3 version.

--- a/Tests/Acceptance/ID3TagEditorTestAcceptanceTest.swift
+++ b/Tests/Acceptance/ID3TagEditorTestAcceptanceTest.swift
@@ -288,10 +288,7 @@ class ID3TagEditorTestAcceptanceTest: XCTestCase {
             tag: id3Tag,
             to: PathLoader().pathFor(name: "example-to-be-modified", fileType: "mp3"),
             andSaveTo: NSHomeDirectory() + "/example-v3-png.mp3"
-            ))
-        
-        let tag = try! id3TagEditor.read(from: NSHomeDirectory() + "/example-v3-png.mp3")
-        print("")
+            ))        
     }
     
     func testWriteTagV3WithCustomPathThatDoesNotExists() {

--- a/Tests/XCTestManifests.swift
+++ b/Tests/XCTestManifests.swift
@@ -415,6 +415,7 @@ extension ID3TagEditorTestAcceptanceTest {
         ("testWriteTagV3ToMp3AsData", testWriteTagV3ToMp3AsData),
         ("testWriteTagV4", testWriteTagV4),
         ("testWriteTagV4WithPng", testWriteTagV4WithPng),
+        ("testWriteTagV4SynchsafeIntegers", testWriteTagV4SynchsafeIntegers)
 
     ]
 }


### PR DESCRIPTION
Add collections and improved capabilities to all public enum API

## Description
Add `CaseIterable`, `Equatable` and `Hashable` protocol to public enum in order to iterate and compare them freely.

## Motivation and Context
Increase ID3TagEditor API flexibility.

## How Has This Been Tested?
Unit test.

## Types of changes
- [X] New feature :sparkles: (non-breaking change which adds functionality)

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/ID3TagEditor/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [X] I have added tests to cover my changes :tada:.
- [X] All new and existing tests passed :white_check_mark:.
