### PR TITLE
Split Frames by version/Validate Frame Creation part 2: #48 

### DIFF
--- a/Source/Tag/ID3Tag.swift
+++ b/Source/Tag/ID3Tag.swift
@@ -80,7 +80,7 @@ public class ID3Tag: CustomDebugStringConvertible {
      - parameter version: the version of the ID3 tag. Versions supported: 2.2, 2.3 and 2.4.
      - parameter frames: the list of frames extracted or to be added to the ID3Tag of an mp3 file.
      */
-    public init(version: ID3Version, frames: [FrameName: ID3Frame]) {
+    init(version: ID3Version, frames: [FrameName: ID3Frame]) {
         self.properties = ID3TagProperties(version: version, size: 0)
         self.frames = frames
     }

--- a/Source/Tag/ID3Tag.swift
+++ b/Source/Tag/ID3Tag.swift
@@ -74,12 +74,6 @@ public class ID3Tag: CustomDebugStringConvertible {
         """
     }
 
-    /**
-     Init an ID3 tag.
-     
-     - parameter version: the version of the ID3 tag. Versions supported: 2.2, 2.3 and 2.4.
-     - parameter frames: the list of frames extracted or to be added to the ID3Tag of an mp3 file.
-     */
     init(version: ID3Version, frames: [FrameName: ID3Frame]) {
         self.properties = ID3TagProperties(version: version, size: 0)
         self.frames = frames

--- a/Tests/Acceptance/ID3TagEditorAcceptanceTest.swift
+++ b/Tests/Acceptance/ID3TagEditorAcceptanceTest.swift
@@ -17,7 +17,7 @@ class ID3TagEditorAcceptanceTest: XCTestCase {
 
     func testFailWrongFilePathFilePath() {
         XCTAssertThrowsError(try id3TagEditor.read(from: "::a wrong path::"))
-        XCTAssertThrowsError(try id3TagEditor.write(tag: ID3Tag(version: .version2, frames: [:]), to: ""))
+        XCTAssertThrowsError(try id3TagEditor.write(tag: ID32v2TagBuilder().build(), to: ""))
     }
 
     // MARK: read

--- a/Tests/Creation/Frame/Content/ID3AlbumArtistFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3AlbumArtistFrameCreatorTest.swift
@@ -20,7 +20,7 @@ class ID3AlbumArtistFrameCreatorTest: XCTestCase {
         )
 
         let newTagBytes = id3AlbumArtistFrameCreator.createFrames(
-            id3Tag: ID3Tag(version: .version3, frames: [:]),
+            id3Tag: ID32v3TagBuilder().build(),
             tag: tagBytes
         )
 
@@ -30,10 +30,9 @@ class ID3AlbumArtistFrameCreatorTest: XCTestCase {
     func testFrameCreationWhenThereIsAnAlbumArtist() {
         let newFrameBytes: [UInt8] = [1, 1]
         let tagAsBytes: [UInt8] = [1, 1, 1]
-        let id3Tag = ID3Tag(
-            version: .version3,
-            frames: [.albumArtist: ID3FrameWithStringContent(content: "::an example album artist::")]
-        )
+        let id3Tag = ID32v3TagBuilder()
+            .albumArtist(frame: ID3FrameWithStringContent(content: "::an example album artist::"))
+            .build()
         let id3AlbumArtistFrameCreator = ID3AlbumArtistFrameCreator(
                 frameCreator: MockFrameFromStringContentCreator(
                         fakeNewFrameAsByte: newFrameBytes,

--- a/Tests/Creation/Frame/Content/ID3AlbumFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3AlbumFrameCreatorTest.swift
@@ -20,7 +20,7 @@ class ID3AlbumFrameCreatorTest: XCTestCase {
         )
 
         let newTagBytes = id3AlbumFrameCreator.createFrames(
-            id3Tag: ID3Tag(version: .version3, frames: [:]),
+            id3Tag: ID32v3TagBuilder().build(),
             tag: tagBytes
         )
 
@@ -30,10 +30,9 @@ class ID3AlbumFrameCreatorTest: XCTestCase {
     func testFrameCreationWhenThereIsAnAlbum() {
         let newFrameBytes: [UInt8] = [1, 1]
         let tagAsBytes: [UInt8] = [1, 1, 1]
-        let id3Tag = ID3Tag(
-            version: .version3,
-            frames: [.album: ID3FrameWithStringContent(content: "::an example album::")]
-        )
+        let id3Tag = ID32v3TagBuilder()
+            .album(frame: ID3FrameWithStringContent(content: "::an example album::"))
+            .build()
         let id3AlbumFrameCreator = ID3AlbumFrameCreator(
                 frameCreator: MockFrameFromStringContentCreator(
                         fakeNewFrameAsByte: newFrameBytes,

--- a/Tests/Creation/Frame/Content/ID3ArtistFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3ArtistFrameCreatorTest.swift
@@ -20,7 +20,7 @@ class ID3ArtistFrameCreatorTest: XCTestCase {
         )
 
         let newTagBytes = id3ArtistFrameCreator.createFrames(
-            id3Tag: ID3Tag(version: .version3, frames: [:]),
+            id3Tag: ID32v3TagBuilder().build(),
             tag: tagBytes
         )
 
@@ -30,10 +30,9 @@ class ID3ArtistFrameCreatorTest: XCTestCase {
     func testFrameCreationWhenThereIsAnArtist() {
         let newFrameBytes: [UInt8] = [1, 1]
         let tagAsBytes: [UInt8] = [1, 1, 1]
-        let id3Tag = ID3Tag(
-            version: .version3,
-            frames: [.artist: ID3FrameWithStringContent(content: "::an example artist::")]
-        )
+        let id3Tag = ID32v3TagBuilder()
+            .artist(frame: ID3FrameWithStringContent(content: "::an example artist::"))
+            .build()
         let id3ArtistFrameCreator = ID3ArtistFrameCreator(
             frameCreator: MockFrameFromStringContentCreator(
                 fakeNewFrameAsByte: newFrameBytes,

--- a/Tests/Creation/Frame/Content/ID3AttachedPicturesFrameCreatorsTest.swift
+++ b/Tests/Creation/Frame/Content/ID3AttachedPicturesFrameCreatorsTest.swift
@@ -21,7 +21,7 @@ class ID3AttachedPicturesFramesCreatorTest: XCTestCase {
         )
 
         let newTagBytes = id3AttachedPictureFrameCreator.createFrames(
-            id3Tag: ID3Tag(version: .version3, frames: [:]),
+            id3Tag: ID32v3TagBuilder().build(),
                 tag: tagBytes
         )
 
@@ -34,7 +34,9 @@ class ID3AttachedPicturesFramesCreatorTest: XCTestCase {
             type: .frontCover,
             format: .jpeg
         )
-        let id3Tag = ID3Tag(version: .version2, frames: [.attachedPicture(.frontCover): attachedPictureFrame])
+        let id3Tag = ID32v2TagBuilder()
+            .attachedPicture(pictureType: .frontCover, frame: attachedPictureFrame)
+            .build()
         let id3AttachedPictureFrameCreator = ID3AttachedPicturesFramesCreator(
                 attachedPictureFrameCreator: ID3AttachedPictureFrameCreator(
                         id3FrameConfiguration: ID3FrameConfiguration(),
@@ -57,7 +59,9 @@ class ID3AttachedPicturesFramesCreatorTest: XCTestCase {
 
     func testFrameCreationWithPngForVersion2() {
         let attachedPictureFrame = ID3FrameAttachedPicture(picture: Data([0x10, 0x10]), type: .frontCover, format: .png)
-        let id3Tag = ID3Tag(version: .version2, frames: [.attachedPicture(.frontCover): attachedPictureFrame])
+        let id3Tag = ID32v2TagBuilder()
+            .attachedPicture(pictureType: .frontCover, frame: attachedPictureFrame)
+            .build()
         let id3AttachedPictureFrameCreator = ID3AttachedPicturesFramesCreator(
                 attachedPictureFrameCreator: ID3AttachedPictureFrameCreator(
                         id3FrameConfiguration: ID3FrameConfiguration(),
@@ -84,7 +88,9 @@ class ID3AttachedPicturesFramesCreatorTest: XCTestCase {
             type: .frontCover,
             format: .jpeg
         )
-        let id3Tag = ID3Tag(version: .version3, frames: [.attachedPicture(.frontCover): attachedPictureFrame])
+        let id3Tag = ID32v3TagBuilder()
+            .attachedPicture(pictureType: .frontCover, frame: attachedPictureFrame)
+            .build()
         let id3AttachedPictureFrameCreator = ID3AttachedPicturesFramesCreator(
                 attachedPictureFrameCreator: ID3AttachedPictureFrameCreator(
                         id3FrameConfiguration: ID3FrameConfiguration(),
@@ -110,7 +116,9 @@ class ID3AttachedPicturesFramesCreatorTest: XCTestCase {
 
     func testFrameCreationWithPngForVersion3() {
         let attachedPictureFrame = ID3FrameAttachedPicture(picture: Data([0x10, 0x10]), type: .frontCover, format: .png)
-        let id3Tag = ID3Tag(version: .version3, frames: [.attachedPicture(.frontCover): attachedPictureFrame])
+        let id3Tag = ID32v3TagBuilder()
+            .attachedPicture(pictureType: .frontCover, frame: attachedPictureFrame)
+            .build()
         let id3AttachedPictureFrameCreator = ID3AttachedPicturesFramesCreator(
                 attachedPictureFrameCreator: ID3AttachedPictureFrameCreator(
                         id3FrameConfiguration: ID3FrameConfiguration(),
@@ -144,13 +152,10 @@ class ID3AttachedPicturesFramesCreatorTest: XCTestCase {
             type: .backCover,
             format: .png
         )
-        let id3Tag = ID3Tag(
-            version: .version3,
-            frames: [
-                .attachedPicture(.frontCover): attachedPictureFrameFront,
-                .attachedPicture(.backCover): attachedPictureFrameBack
-            ]
-        )
+        let id3Tag = ID32v3TagBuilder()
+            .attachedPicture(pictureType: .frontCover, frame: attachedPictureFrameFront)
+            .attachedPicture(pictureType: .backCover, frame: attachedPictureFrameBack)
+            .build()
         let id3AttachedPictureFrameCreator = ID3AttachedPicturesFramesCreator(
                 attachedPictureFrameCreator: ID3AttachedPictureFrameCreator(
                         id3FrameConfiguration: ID3FrameConfiguration(),

--- a/Tests/Creation/Frame/Content/ID3ComposerFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3ComposerFrameCreatorTest.swift
@@ -20,7 +20,7 @@ class ID3ComposerFrameCreatorTest: XCTestCase {
         )
 
         let newTagBytes = id3ComposerFrameCreator.createFrames(
-            id3Tag: ID3Tag(version: .version3, frames: [:]),
+            id3Tag: ID32v3TagBuilder().build(),
             tag: tagBytes
         )
 
@@ -30,10 +30,10 @@ class ID3ComposerFrameCreatorTest: XCTestCase {
     func testFrameCreationWhenThereIsAComposer() {
         let newFrameBytes: [UInt8] = [1, 1]
         let tagAsBytes: [UInt8] = [1, 1, 1]
-        let id3Tag = ID3Tag(
-            version: .version3,
-            frames: [.composer: ID3FrameWithStringContent(content: "::an example composer::")]
-        )
+        let id3Tag = ID32v3TagBuilder()
+            .composer(frame: ID3FrameWithStringContent(content: "::an example composer::"))
+            .build()
+
         let id3ComposerFrameCreator = ID3ComposerFrameCreator(
             frameCreator: MockFrameFromStringContentCreator(
                 fakeNewFrameAsByte: newFrameBytes,

--- a/Tests/Creation/Frame/Content/ID3ConductorFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3ConductorFrameCreatorTest.swift
@@ -33,7 +33,7 @@ class ID3ConductorFrameCreatorTest: XCTestCase {
         let id3Tag = ID32v3TagBuilder()
             .conductor(frame: ID3FrameWithStringContent(content: "::an example conductor::"))
             .build()
-            
+
         let id3ConductorFrameCreator = ID3ConductorFrameCreator(
             frameCreator: MockFrameFromStringContentCreator(
                 fakeNewFrameAsByte: newFrameBytes,

--- a/Tests/Creation/Frame/Content/ID3ConductorFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3ConductorFrameCreatorTest.swift
@@ -20,7 +20,7 @@ class ID3ConductorFrameCreatorTest: XCTestCase {
         )
 
         let newTagBytes = id3ConductorFrameCreator.createFrames(
-            id3Tag: ID3Tag(version: .version3, frames: [:]),
+            id3Tag: ID32v3TagBuilder().build(),
             tag: tagBytes
         )
 
@@ -30,10 +30,10 @@ class ID3ConductorFrameCreatorTest: XCTestCase {
     func testFrameCreationWhenThereIsAConductor() {
         let newFrameBytes: [UInt8] = [1, 1]
         let tagAsBytes: [UInt8] = [1, 1, 1]
-        let id3Tag = ID3Tag(
-            version: .version3,
-            frames: [.conductor: ID3FrameWithStringContent(content: "::an example conductor::")]
-        )
+        let id3Tag = ID32v3TagBuilder()
+            .conductor(frame: ID3FrameWithStringContent(content: "::an example conductor::"))
+            .build()
+            
         let id3ConductorFrameCreator = ID3ConductorFrameCreator(
             frameCreator: MockFrameFromStringContentCreator(
                 fakeNewFrameAsByte: newFrameBytes,

--- a/Tests/Creation/Frame/Content/ID3ContentGroupingFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3ContentGroupingFrameCreatorTest.swift
@@ -20,7 +20,7 @@ class ID3ContentGroupingFrameCreatorTest: XCTestCase {
         )
 
         let newTagBytes = id3ContentGroupingFrameCreator.createFrames(
-            id3Tag: ID3Tag(version: .version3, frames: [:]),
+            id3Tag: ID32v3TagBuilder().build(),
             tag: tagBytes
         )
 
@@ -30,10 +30,10 @@ class ID3ContentGroupingFrameCreatorTest: XCTestCase {
     func testFrameCreationWhenThereIsAContentGrouping() {
         let newFrameBytes: [UInt8] = [1, 1]
         let tagAsBytes: [UInt8] = [1, 1, 1]
-        let id3Tag = ID3Tag(
-            version: .version3,
-            frames: [.contentGrouping: ID3FrameWithStringContent(content: "::an example content grouping::")]
-        )
+        let id3Tag = ID32v3TagBuilder()
+            .contentGrouping(frame: ID3FrameWithStringContent(content: "::an example content grouping::"))
+            .build()
+            
         let id3ContentGroupingFrameCreator = ID3ContentGroupingFrameCreator(
             frameCreator: MockFrameFromStringContentCreator(
                 fakeNewFrameAsByte: newFrameBytes,

--- a/Tests/Creation/Frame/Content/ID3ContentGroupingFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3ContentGroupingFrameCreatorTest.swift
@@ -33,7 +33,7 @@ class ID3ContentGroupingFrameCreatorTest: XCTestCase {
         let id3Tag = ID32v3TagBuilder()
             .contentGrouping(frame: ID3FrameWithStringContent(content: "::an example content grouping::"))
             .build()
-            
+
         let id3ContentGroupingFrameCreator = ID3ContentGroupingFrameCreator(
             frameCreator: MockFrameFromStringContentCreator(
                 fakeNewFrameAsByte: newFrameBytes,

--- a/Tests/Creation/Frame/Content/ID3CopyrightFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3CopyrightFrameCreatorTest.swift
@@ -33,7 +33,7 @@ class ID3CopyrightFrameCreatorTest: XCTestCase {
         let id3Tag = ID32v3TagBuilder()
             .copyright(frame: ID3FrameWithStringContent(content: "::an example copyright::"))
             .build()
-            
+
         let id3CopyrightFrameCreator = ID3CopyrightFrameCreator(
             frameCreator: MockFrameFromStringContentCreator(
                 fakeNewFrameAsByte: newFrameBytes,

--- a/Tests/Creation/Frame/Content/ID3CopyrightFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3CopyrightFrameCreatorTest.swift
@@ -20,7 +20,7 @@ class ID3CopyrightFrameCreatorTest: XCTestCase {
         )
 
         let newTagBytes = id3CopyrightFrameCreator.createFrames(
-            id3Tag: ID3Tag(version: .version3, frames: [:]),
+            id3Tag: ID32v3TagBuilder().build(),
             tag: tagBytes
         )
 
@@ -30,10 +30,10 @@ class ID3CopyrightFrameCreatorTest: XCTestCase {
     func testFrameCreationWhenThereIsACopyright() {
         let newFrameBytes: [UInt8] = [1, 1]
         let tagAsBytes: [UInt8] = [1, 1, 1]
-        let id3Tag = ID3Tag(
-            version: .version3,
-            frames: [.copyright: ID3FrameWithStringContent(content: "::an example copyright::")]
-        )
+        let id3Tag = ID32v3TagBuilder()
+            .copyright(frame: ID3FrameWithStringContent(content: "::an example copyright::"))
+            .build()
+            
         let id3CopyrightFrameCreator = ID3CopyrightFrameCreator(
             frameCreator: MockFrameFromStringContentCreator(
                 fakeNewFrameAsByte: newFrameBytes,

--- a/Tests/Creation/Frame/Content/ID3DiscPositionFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3DiscPositionFrameCreatorTest.swift
@@ -20,7 +20,7 @@ class ID3DiscPositionFrameCreatorTest: XCTestCase {
         )
 
         let newTagBytes = id3DiscPositionFrameCreator.createFrames(
-            id3Tag: ID3Tag(version: .version3, frames: [:]),
+            id3Tag: ID32v3TagBuilder().build(),
             tag: tagBytes
         )
 
@@ -30,10 +30,10 @@ class ID3DiscPositionFrameCreatorTest: XCTestCase {
     func testFrameCreationWhenThereIsADiscPosition() {
         let newFrameBytes: [UInt8] = [1, 1]
         let tagAsBytes: [UInt8] = [1, 1, 1]
-        let id3Tag = ID3Tag(
-            version: .version3,
-            frames: [.discPosition: ID3FramePartOfTotal(part: 1, total: 3)]
-        )
+        let id3Tag = ID32v3TagBuilder()
+            .discPosition(frame: ID3FramePartOfTotal(part: 1, total: 3))
+            .build()
+                        
         let id3GenreFrameCreator = ID3DiscPositionFrameCreator(
                 frameCreator: MockFrameFromStringContentCreator(
                         fakeNewFrameAsByte: newFrameBytes,

--- a/Tests/Creation/Frame/Content/ID3DiscPositionFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3DiscPositionFrameCreatorTest.swift
@@ -33,7 +33,7 @@ class ID3DiscPositionFrameCreatorTest: XCTestCase {
         let id3Tag = ID32v3TagBuilder()
             .discPosition(frame: ID3FramePartOfTotal(part: 1, total: 3))
             .build()
-                        
+
         let id3GenreFrameCreator = ID3DiscPositionFrameCreator(
                 frameCreator: MockFrameFromStringContentCreator(
                         fakeNewFrameAsByte: newFrameBytes,

--- a/Tests/Creation/Frame/Content/ID3EncodedByFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3EncodedByFrameCreatorTest.swift
@@ -20,7 +20,7 @@ class ID3EncodedByFrameCreatorTest: XCTestCase {
         )
 
         let newTagBytes = id3EncodedByFrameCreator.createFrames(
-            id3Tag: ID3Tag(version: .version3, frames: [:]),
+            id3Tag: ID32v3TagBuilder().build(),
             tag: tagBytes
         )
 
@@ -30,10 +30,10 @@ class ID3EncodedByFrameCreatorTest: XCTestCase {
     func testFrameCreationWhenThereIsAnEncodedBy() {
         let newFrameBytes: [UInt8] = [1, 1]
         let tagAsBytes: [UInt8] = [1, 1, 1]
-        let id3Tag = ID3Tag(
-            version: .version3,
-            frames: [.encodedBy: ID3FrameWithStringContent(content: "::an example encodedBy::")]
-        )
+        let id3Tag = ID32v3TagBuilder()
+            .encodedBy(frame: ID3FrameWithStringContent(content: "::an example encodedBy::"))
+            .build()
+            
         let id3EncodedByFrameCreator = ID3EncodedByFrameCreator(
             frameCreator: MockFrameFromStringContentCreator(
                 fakeNewFrameAsByte: newFrameBytes,

--- a/Tests/Creation/Frame/Content/ID3EncodedByFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3EncodedByFrameCreatorTest.swift
@@ -33,7 +33,7 @@ class ID3EncodedByFrameCreatorTest: XCTestCase {
         let id3Tag = ID32v3TagBuilder()
             .encodedBy(frame: ID3FrameWithStringContent(content: "::an example encodedBy::"))
             .build()
-            
+
         let id3EncodedByFrameCreator = ID3EncodedByFrameCreator(
             frameCreator: MockFrameFromStringContentCreator(
                 fakeNewFrameAsByte: newFrameBytes,

--- a/Tests/Creation/Frame/Content/ID3EncoderSettingsFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3EncoderSettingsFrameCreatorTest.swift
@@ -20,7 +20,7 @@ class ID3EncoderSettingsFrameCreatorTest: XCTestCase {
         )
 
         let newTagBytes = id3EncoderSettingsFrameCreator.createFrames(
-            id3Tag: ID3Tag(version: .version3, frames: [:]),
+            id3Tag: ID32v3TagBuilder().build(),
             tag: tagBytes
         )
 
@@ -30,10 +30,10 @@ class ID3EncoderSettingsFrameCreatorTest: XCTestCase {
     func testFrameCreationWhenThereAreEncoderSettings() {
         let newFrameBytes: [UInt8] = [1, 1]
         let tagAsBytes: [UInt8] = [1, 1, 1]
-        let id3Tag = ID3Tag(
-            version: .version3,
-            frames: [.encoderSettings: ID3FrameWithStringContent(content: "::an example encoder settings::")]
-        )
+        let id3Tag = ID32v3TagBuilder()
+            .encoderSettings(frame: ID3FrameWithStringContent(content: "::an example encoder settings::"))
+            .build()
+            
         let id3EncoderSettingsFrameCreator = ID3EncoderSettingsFrameCreator(
             frameCreator: MockFrameFromStringContentCreator(
                 fakeNewFrameAsByte: newFrameBytes,

--- a/Tests/Creation/Frame/Content/ID3EncoderSettingsFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3EncoderSettingsFrameCreatorTest.swift
@@ -33,7 +33,7 @@ class ID3EncoderSettingsFrameCreatorTest: XCTestCase {
         let id3Tag = ID32v3TagBuilder()
             .encoderSettings(frame: ID3FrameWithStringContent(content: "::an example encoder settings::"))
             .build()
-            
+
         let id3EncoderSettingsFrameCreator = ID3EncoderSettingsFrameCreator(
             frameCreator: MockFrameFromStringContentCreator(
                 fakeNewFrameAsByte: newFrameBytes,

--- a/Tests/Creation/Frame/Content/ID3FileOwnerFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3FileOwnerFrameCreatorTest.swift
@@ -20,7 +20,7 @@ class ID3FileOwnerFrameCreatorTest: XCTestCase {
         )
 
         let newTagBytes = id3FileOwnerFrameCreator.createFrames(
-            id3Tag: ID3Tag(version: .version3, frames: [:]),
+            id3Tag: ID32v3TagBuilder().build(),
             tag: tagBytes
         )
 
@@ -30,10 +30,10 @@ class ID3FileOwnerFrameCreatorTest: XCTestCase {
     func testFrameCreationWhenThereIsAFileOwner() {
         let newFrameBytes: [UInt8] = [1, 1]
         let tagAsBytes: [UInt8] = [1, 1, 1]
-        let id3Tag = ID3Tag(
-            version: .version3,
-            frames: [.fileOwner: ID3FrameWithStringContent(content: "::an example file owner::")]
-        )
+        let id3Tag = ID32v3TagBuilder()
+            .fileOwner(frame: ID3FrameWithStringContent(content: "::an example file owner::"))
+            .build()
+            
         let id3FileOwnerFrameCreator = ID3FileOwnerFrameCreator(
             frameCreator: MockFrameFromStringContentCreator(
                 fakeNewFrameAsByte: newFrameBytes,

--- a/Tests/Creation/Frame/Content/ID3FileOwnerFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3FileOwnerFrameCreatorTest.swift
@@ -33,7 +33,7 @@ class ID3FileOwnerFrameCreatorTest: XCTestCase {
         let id3Tag = ID32v3TagBuilder()
             .fileOwner(frame: ID3FrameWithStringContent(content: "::an example file owner::"))
             .build()
-            
+
         let id3FileOwnerFrameCreator = ID3FileOwnerFrameCreator(
             frameCreator: MockFrameFromStringContentCreator(
                 fakeNewFrameAsByte: newFrameBytes,

--- a/Tests/Creation/Frame/Content/ID3FrameCreatorsChainTest.swift
+++ b/Tests/Creation/Frame/Content/ID3FrameCreatorsChainTest.swift
@@ -14,7 +14,7 @@ class ID3FrameCreatorsChainTest: XCTestCase {
         let anotherFrameCreatorChain = MockID3FrameCreatorsChain()
         id3FrameCreatorsChain.nextCreator = anotherFrameCreatorChain
 
-        _ = id3FrameCreatorsChain.createFrames(id3Tag: ID3Tag(version: .version2, frames: [:]), tag: [])
+        _ = id3FrameCreatorsChain.createFrames(id3Tag: ID32v2TagBuilder().build(), tag: [])
 
         XCTAssertTrue(anotherFrameCreatorChain.createFramesHasBeenCalled)
     }
@@ -24,7 +24,7 @@ class ID3FrameCreatorsChainTest: XCTestCase {
         let currentTagBytes: [UInt8] = [0x1, 0x1]
 
         let newTagBytes = id3FrameCreatorsChain.createFrames(
-            id3Tag: ID3Tag(version: .version2, frames: [:]),
+            id3Tag: ID32v2TagBuilder().build(),
             tag: currentTagBytes
         )
 

--- a/Tests/Creation/Frame/Content/ID3GenreFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3GenreFrameCreatorTest.swift
@@ -20,7 +20,7 @@ class ID3GenreFrameCreatorTest: XCTestCase {
         )
 
         let newTagBytes = id3GenreFrameCreator.createFrames(
-            id3Tag: ID3Tag(version: .version3, frames: [:]),
+            id3Tag: ID32v3TagBuilder().build(),
             tag: tagBytes
         )
 
@@ -30,10 +30,10 @@ class ID3GenreFrameCreatorTest: XCTestCase {
     func testFrameCreationWhenThereIsAGenre() {
         let newFrameBytes: [UInt8] = [1, 1]
         let tagAsBytes: [UInt8] = [1, 1, 1]
-        let id3Tag = ID3Tag(
-            version: .version3,
-            frames: [.genre: ID3FrameGenre(genre: .metal, description: "Metalcore")]
-        )
+        let id3Tag = ID32v3TagBuilder()
+            .genre(frame: ID3FrameGenre(genre: .metal, description: "Metalcore"))
+            .build()
+
         let id3GenreFrameCreator = ID3GenreFrameCreator(
                 frameCreator: MockFrameFromStringContentCreator(
                         fakeNewFrameAsByte: newFrameBytes,

--- a/Tests/Creation/Frame/Content/ID3LyricistFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3LyricistFrameCreatorTest.swift
@@ -20,7 +20,7 @@ class ID3LyricistFrameCreatorTest: XCTestCase {
         )
 
         let newTagBytes = id3LyricistFrameCreator.createFrames(
-            id3Tag: ID3Tag(version: .version3, frames: [:]),
+            id3Tag: ID32v3TagBuilder().build(),
             tag: tagBytes
         )
 

--- a/Tests/Creation/Frame/Content/ID3MixArtistFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3MixArtistFrameCreatorTest.swift
@@ -20,7 +20,7 @@ class ID3MixArtistFrameCreatorTest: XCTestCase {
         )
 
         let newTagBytes = id3MixArtistFrameCreator.createFrames(
-            id3Tag: ID3Tag(version: .version3, frames: [:]),
+            id3Tag: ID32v3TagBuilder().build(),
             tag: tagBytes
         )
 

--- a/Tests/Creation/Frame/Content/ID3PublisherFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3PublisherFrameCreatorTest.swift
@@ -20,7 +20,7 @@ class ID3PublisherFrameCreatorTest: XCTestCase {
         )
 
         let newTagBytes = id3PublisherFrameCreator.createFrames(
-            id3Tag: ID3Tag(version: .version3, frames: [:]),
+            id3Tag: ID32v3TagBuilder().build(),
             tag: tagBytes
         )
 

--- a/Tests/Creation/Frame/Content/ID3RecordingYearFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3RecordingYearFrameCreatorTest.swift
@@ -20,7 +20,7 @@ class ID3RecordingYearFrameCreatorTest: XCTestCase {
         )
 
         let newTagBytes = id3YearFrameCreator.createFrames(
-            id3Tag: ID3Tag(version: .version3, frames: [:]),
+            id3Tag: ID32v3TagBuilder().build(),
             tag: tagBytes
         )
 
@@ -37,10 +37,9 @@ class ID3RecordingYearFrameCreatorTest: XCTestCase {
             id3FrameConfiguration: ID3FrameConfiguration()
         )
         let recordingDateTime = RecordingDateTime(date: RecordingDate(day: nil, month: nil, year: 2018), time: nil)
-        let id3tag = ID3Tag(
-            version: .version4,
-            frames: [.recordingDateTime: ID3FrameRecordingDateTime(recordingDateTime: recordingDateTime)]
-        )
+        let id3tag = ID32v4TagBuilder()
+            .recordingDateTime(frame: ID3FrameRecordingDateTime(recordingDateTime: recordingDateTime))
+            .build()
 
         let newTagBytes = id3YearFrameCreator.createFrames(id3Tag: id3tag, tag: tagBytes)
 
@@ -50,10 +49,10 @@ class ID3RecordingYearFrameCreatorTest: XCTestCase {
     func testFrameCreationWhenThereIsAnYear() {
         let newFrameBytes: [UInt8] = [1, 1]
         let tagAsBytes: [UInt8] = [1, 1, 1]
-        let id3Tag = ID3Tag(
-            version: .version3,
-            frames: [.recordingYear: ID3FrameRecordingYear(year: 2018)]
-        )
+        let id3Tag = ID32v3TagBuilder()
+            .recordingYear(frame: ID3FrameRecordingYear(year: 2018))
+            .build()
+
         let id3TitleFrameCreator = ID3RecordingYearFrameCreator(
                 frameCreator: MockFrameFromStringContentCreator(
                         fakeNewFrameAsByte: newFrameBytes,

--- a/Tests/Creation/Frame/Content/ID3SubtitleFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3SubtitleFrameCreatorTest.swift
@@ -20,7 +20,7 @@ class ID3SubtitleFrameCreatorTest: XCTestCase {
         )
 
         let newTagBytes = id3SubtitleFrameCreator.createFrames(
-            id3Tag: ID3Tag(version: .version3, frames: [:]),
+            id3Tag: ID32v3TagBuilder().build(),
             tag: tagBytes
         )
 

--- a/Tests/Creation/Frame/Content/ID3TitleFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3TitleFrameCreatorTest.swift
@@ -20,7 +20,7 @@ class ID3TitleFrameCreatorTest: XCTestCase {
         )
 
         let newTagBytes = id3TitleFrameCreator.createFrames(
-            id3Tag: ID3Tag(version: .version3, frames: [:]),
+            id3Tag: ID32v3TagBuilder().build(),
             tag: tagBytes
         )
 
@@ -30,10 +30,10 @@ class ID3TitleFrameCreatorTest: XCTestCase {
     func testFrameCreationWhenThereIsATitle() {
         let newFrameBytes: [UInt8] = [1, 1]
         let tagAsBytes: [UInt8] = [1, 1, 1]
-        let id3Tag = ID3Tag(
-            version: .version3,
-            frames: [.title: ID3FrameWithStringContent(content: "::an example title::")]
-        )
+        let id3Tag = ID32v3TagBuilder()
+            .title(frame: ID3FrameWithStringContent(content: "::an example title::"))
+            .build()
+
         let id3TitleFrameCreator = ID3TitleFrameCreator(
                 frameCreator: MockFrameFromStringContentCreator(
                         fakeNewFrameAsByte: newFrameBytes,

--- a/Tests/Creation/Frame/Content/ID3TrackPositionFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3TrackPositionFrameCreatorTest.swift
@@ -20,7 +20,7 @@ class ID3TrackPositionCreatorTest: XCTestCase {
         )
 
         let newTagBytes = id3TrackPositionFrameCreator.createFrames(
-            id3Tag: ID3Tag(version: .version3, frames: [:]),
+            id3Tag: ID32v3TagBuilder().build(),
             tag: tagBytes
         )
 
@@ -30,10 +30,10 @@ class ID3TrackPositionCreatorTest: XCTestCase {
     func testFrameCreationWhenThereIsATrackPosition() {
         let newFrameBytes: [UInt8] = [1, 1]
         let tagAsBytes: [UInt8] = [1, 1, 1]
-        let id3Tag = ID3Tag(
-            version: .version3,
-            frames: [.trackPosition: ID3FramePartOfTotal(part: 1, total: 10)]
-        )
+        let id3Tag = ID32v3TagBuilder()
+            .trackPosition(frame: ID3FramePartOfTotal(part: 1, total: 10))
+            .build()
+
         let id3GenreFrameCreator = ID3TrackPositionFrameCreator(
                 frameCreator: MockFrameFromStringContentCreator(
                         fakeNewFrameAsByte: newFrameBytes,

--- a/Tests/Creation/Frame/Content/ID3UnsyncronizedLyricsFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3UnsyncronizedLyricsFrameCreatorTest.swift
@@ -14,29 +14,32 @@ class ID3UnsyncronizedLyricsFrameCreatorTest: XCTestCase {
         let creator = ID3UnsyncronizedLyricsFrameCreator(
             unsynchronisedLyricForLanguageFrameCreator: MockUnsynchronisedLyricForLanguageFrameCreator()
         )
-
+        
         let frame = creator.createFrames(id3Tag: ID3Tag(version: .version3, frames: [:]), tag: [])
-
+        
         XCTAssertEqual(frame, [])
     }
-
+    
     func testCreateFrameForValidData() {
         let creator = ID3UnsyncronizedLyricsFrameCreator(
             unsynchronisedLyricForLanguageFrameCreator: MockUnsynchronisedLyricForLanguageFrameCreator()
         )
-
-        let frame = creator.createFrames(id3Tag: ID3Tag(version: .version3,
-                                                        frames: [
-                                                            .unsynchronizedLyrics(.ita): ID3FrameUnsynchronisedLyrics(
-                                                                language: .ita,
-                                                                contentDescription: "decription",
-                                                                content: "content"
-                                                            )]),
-                                         tag: [])
-
+        
+        let frame = creator.createFrames(id3Tag: aTagWithUnsynchronisedLyrics(), tag: [])
+        
         XCTAssertEqual(frame, [0x01])
     }
-
+    
+    private func aTagWithUnsynchronisedLyrics() -> ID3Tag {
+        return ID32v3TagBuilder()
+            .unsynchronisedLyrics(language: .ita, frame: ID3FrameUnsynchronisedLyrics(
+                language: .ita,
+                contentDescription: "decription",
+                content: "content"
+            ))
+            .build()
+    }
+    
     static let allTests = [
         ("testNothingIsCreatedWheLyricsDataIsNotSet", testNothingIsCreatedWheLyricsDataIsNotSet),
         ("testCreateFrameForValidData", testCreateFrameForValidData)

--- a/Tests/Creation/Frame/Content/ID3UnsyncronizedLyricsFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3UnsyncronizedLyricsFrameCreatorTest.swift
@@ -14,22 +14,22 @@ class ID3UnsyncronizedLyricsFrameCreatorTest: XCTestCase {
         let creator = ID3UnsyncronizedLyricsFrameCreator(
             unsynchronisedLyricForLanguageFrameCreator: MockUnsynchronisedLyricForLanguageFrameCreator()
         )
-        
-        let frame = creator.createFrames(id3Tag: ID3Tag(version: .version3, frames: [:]), tag: [])
-        
+
+        let frame = creator.createFrames(id3Tag: ID32v3TagBuilder().build(), tag: [])
+
         XCTAssertEqual(frame, [])
     }
-    
+
     func testCreateFrameForValidData() {
         let creator = ID3UnsyncronizedLyricsFrameCreator(
             unsynchronisedLyricForLanguageFrameCreator: MockUnsynchronisedLyricForLanguageFrameCreator()
         )
-        
+
         let frame = creator.createFrames(id3Tag: aTagWithUnsynchronisedLyrics(), tag: [])
-        
+
         XCTAssertEqual(frame, [0x01])
     }
-    
+
     private func aTagWithUnsynchronisedLyrics() -> ID3Tag {
         return ID32v3TagBuilder()
             .unsynchronisedLyrics(language: .ita, frame: ID3FrameUnsynchronisedLyrics(
@@ -39,7 +39,7 @@ class ID3UnsyncronizedLyricsFrameCreatorTest: XCTestCase {
             ))
             .build()
     }
-    
+
     static let allTests = [
         ("testNothingIsCreatedWheLyricsDataIsNotSet", testNothingIsCreatedWheLyricsDataIsNotSet),
         ("testCreateFrameForValidData", testCreateFrameForValidData)

--- a/Tests/Creation/Frame/Content/ID3iTunesGroupingFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3iTunesGroupingFrameCreatorTest.swift
@@ -20,7 +20,7 @@ class ID3iTunesGroupingFrameCreatorTest: XCTestCase {
         )
 
         let newTagBytes = id3iTunesGroupingFrameCreator.createFrames(
-            id3Tag: ID3Tag(version: .version3, frames: [:]),
+            id3Tag: ID32v3TagBuilder().build(),
             tag: tagBytes
         )
 

--- a/Tests/Creation/Frame/Content/ID3iTunesMovementCountFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3iTunesMovementCountFrameCreatorTest.swift
@@ -21,7 +21,7 @@ class ID3iTunesMovementCountFrameCreatorTest: XCTestCase {
         )
 
         let newTagBytes = id3MovementCountFrameCreator.createFrames(
-            id3Tag: ID3Tag(version: .version3, frames: [:]),
+            id3Tag: ID32v3TagBuilder().build(),
             tag: tagBytes
         )
 

--- a/Tests/Creation/Frame/Content/ID3iTunesMovementIndexFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3iTunesMovementIndexFrameCreatorTest.swift
@@ -20,7 +20,7 @@ class ID3iTunesMovementIndexFrameCreatorTest: XCTestCase {
         )
 
         let newTagBytes = id3MovementIndexFrameCreator.createFrames(
-            id3Tag: ID3Tag(version: .version3, frames: [:]),
+            id3Tag: ID32v3TagBuilder().build(),
             tag: tagBytes
         )
 

--- a/Tests/Creation/Frame/Content/ID3iTunesMovementNameFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3iTunesMovementNameFrameCreatorTest.swift
@@ -20,7 +20,7 @@ class ID3iTunesMovementNameFrameCreatorTest: XCTestCase {
         )
 
         let newTagBytes = id3MovementNameFrameCreator.createFrames(
-            id3Tag: ID3Tag(version: .version3, frames: [:]),
+            id3Tag: ID32v3TagBuilder().build(),
             tag: tagBytes
         )
 

--- a/Tests/Creation/Frame/Content/ID3iTunesPodcastCategoryFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3iTunesPodcastCategoryFrameCreatorTest.swift
@@ -20,7 +20,7 @@ class ID3iTunesPodcastCategoryFrameCreatorTest: XCTestCase {
         )
 
         let newTagBytes = id3PodcastCategoryFrameCreator.createFrames(
-            id3Tag: ID3Tag(version: .version3, frames: [:]),
+            id3Tag: ID32v3TagBuilder().build(),
             tag: tagBytes
         )
 

--- a/Tests/Creation/Frame/Content/ID3iTunesPodcastDescriptionFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3iTunesPodcastDescriptionFrameCreatorTest.swift
@@ -20,7 +20,7 @@ class ID3iTunesPodcastDescriptionFrameCreatorTest: XCTestCase {
         )
 
         let newTagBytes = id3PodcastDescriptionFrameCreator.createFrames(
-            id3Tag: ID3Tag(version: .version3, frames: [:]),
+            id3Tag: ID32v3TagBuilder().build(),
             tag: tagBytes
         )
 

--- a/Tests/Creation/Frame/Content/ID3iTunesPodcastIDFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3iTunesPodcastIDFrameCreatorTest.swift
@@ -20,7 +20,7 @@ class ID3iTunesPodcastIDFrameCreatorTest: XCTestCase {
         )
 
         let newTagBytes = id3PodcastIDFrameCreator.createFrames(
-            id3Tag: ID3Tag(version: .version3, frames: [:]),
+            id3Tag: ID32v3TagBuilder().build(),
             tag: tagBytes
         )
 

--- a/Tests/Creation/Frame/Content/ID3iTunesPodcastKeywordsFrameCreatorTest.swift
+++ b/Tests/Creation/Frame/Content/ID3iTunesPodcastKeywordsFrameCreatorTest.swift
@@ -20,7 +20,7 @@ class ID3iTunesPodcastKeywordsFrameCreatorTest: XCTestCase {
         )
 
         let newTagBytes = id3PodcastKeywordsFrameCreator.createFrames(
-            id3Tag: ID3Tag(version: .version3, frames: [:]),
+            id3Tag: ID32v3TagBuilder().build(),
             tag: tagBytes
         )
 

--- a/Tests/Creation/Tag/ID3TagCreatorTest.swift
+++ b/Tests/Creation/Tag/ID3TagCreatorTest.swift
@@ -15,7 +15,7 @@ class ID3TagCreatorTest: XCTestCase {
                                                       id3TagConfiguration: ID3TagConfiguration())
         let id3TagCreator = ID3TagCreator(id3FramesCreator: id3FramesCreator, id3TagHeaderCreator: id3TagHeaderCreator)
 
-        XCTAssertThrowsError(try id3TagCreator.create(id3Tag: ID3Tag(version: .version3, frames: [:])))
+        XCTAssertThrowsError(try id3TagCreator.create(id3Tag: ID32v3TagBuilder().build()))
     }
 
     func testTagTooBig() {
@@ -25,7 +25,7 @@ class ID3TagCreatorTest: XCTestCase {
                                                       id3TagConfiguration: ID3TagConfiguration())
         let id3TagCreator = ID3TagCreator(id3FramesCreator: id3FramesCreator, id3TagHeaderCreator: id3TagHeaderCreator)
 
-        XCTAssertThrowsError(try id3TagCreator.create(id3Tag: ID3Tag(version: .version3, frames: [:])))
+        XCTAssertThrowsError(try id3TagCreator.create(id3Tag: ID32v3TagBuilder().build()))
     }
 
     func testGenerateValidData() {
@@ -36,7 +36,7 @@ class ID3TagCreatorTest: XCTestCase {
         let id3TagCreator = ID3TagCreator(id3FramesCreator: id3FramesCreator, id3TagHeaderCreator: id3TagHeaderCreator)
 
         XCTAssertEqual(
-                try? id3TagCreator.create(id3Tag: ID3Tag(version: .version3, frames: [:])),
+                try? id3TagCreator.create(id3Tag: ID32v3TagBuilder().build()),
                 Data(ID3TagConfiguration().headerFor(version: .version3)
                         + [0x0, 0x3, 0x2, 0x22, 0x33] + [UInt8](repeating: 0x0, count: 2048)
                 )


### PR DESCRIPTION
Split Frames by version/Validate Frame Creation

## Description
Change ID3Tag init access modifier to `internal` so that user of the library are forced to use ID3Tag builders.

## Motivation and Context
Improve ID3TagEditor api.

## How Has This Been Tested?
Unit tests and Acceptance tests.

## Types of changes
- [X] New feature :sparkles: (non-breaking change which adds functionality)
- [X] Breaking change :boom: (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/ID3TagEditor/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [X] I have added tests to cover my changes :tada:.
- [X] All new and existing tests passed :white_check_mark:.
