### PR TITLE
Added all missing Text information frames

### DIFF
--- a/Source/Frame/FrameType.swift
+++ b/Source/Frame/FrameType.swift
@@ -41,7 +41,27 @@ enum FrameType: String, Equatable {
     case iTunesPodcastID = "iTunesPodcastID"
     case iTunesPodcastKeywords = "iTunesPodcastKeywords"
     case invalid = ""
-
+    case beatsPerMinute = "beatsPerMinute"
+    case contentType = "contentType"
+    case playlistDelay = "playlistDelay"
+    case fileType = "fileType"
+    case time = "time"
+    case initialKey = "initialKey"
+    case languages = "languages"
+    case length = "length"
+    case mediaType = "mediaType"
+    case originalAlbumTitle = "originalAlbumTitle"
+    case originalFilename = "originalFilename"
+    case originalLyricists = "originalLyricists"
+    case originalArtists = "originalArtists"
+    case originalReleaseYear = "originalReleaseYear"
+    case recordingDate = "recordingDate"
+    case internetRadioStationName = "internetRadioStationName"
+    case internetRadioStationOwner = "internetRadioStationOwner"
+    case size = "size"
+    case internationalStandardRecordingCode = "internationalStandardRecordingCode"
+    case year = "year"
+    
     static func == (lhs: FrameType, rhs: FrameType) -> Bool {
         return lhs.rawValue == rhs.rawValue
     }

--- a/Source/Frame/FrameType.swift
+++ b/Source/Frame/FrameType.swift
@@ -61,7 +61,6 @@ enum FrameType: String, Equatable {
     case size = "size"
     case internationalStandardRecordingCode = "internationalStandardRecordingCode"
     case year = "year"
-    
     static func == (lhs: FrameType, rhs: FrameType) -> Bool {
         return lhs.rawValue == rhs.rawValue
     }

--- a/Source/Frame/ID3FrameConfiguration.swift
+++ b/Source/Frame/ID3FrameConfiguration.swift
@@ -56,7 +56,26 @@ class ID3FrameConfiguration {
         .iTunesPodcastCategory: [UInt8]("TCAT".utf8),
         .iTunesPodcastDescription: [UInt8]("TDES".utf8),
         .iTunesPodcastID: [UInt8]("TGID".utf8),
-        .iTunesPodcastKeywords: [UInt8]("TKWD".utf8)
+        .iTunesPodcastKeywords: [UInt8]("TKWD".utf8),
+        .beatsPerMinute: [UInt8]("TBPM".utf8),
+        .playlistDelay: [UInt8]("TDLY".utf8),
+        .fileType: [UInt8]("TFLT".utf8),
+        .time: [UInt8]("TIME".utf8),
+        .initialKey: [UInt8]("TKEY".utf8),
+        .languages: [UInt8]("TLAN".utf8),
+        .length: [UInt8]("TLEN".utf8),
+        .mediaType: [UInt8]("TMED".utf8),
+        .originalAlbumTitle: [UInt8]("TOAL".utf8),
+        .originalFilename: [UInt8]("TOFN".utf8),
+        .originalLyricists: [UInt8]("TOLY".utf8),
+        .originalArtists: [UInt8]("TOPE".utf8),
+        .originalReleaseYear: [UInt8]("TORY".utf8),
+        .recordingDate: [UInt8]("TRDA".utf8),
+        .internetRadioStationName: [UInt8]("TRSN".utf8),
+        .internetRadioStationOwner: [UInt8]("TRSO".utf8),
+        .size: [UInt8]("TSIZ".utf8),
+        .internationalStandardRecordingCode: [UInt8]("TSRC".utf8),
+        .year: [UInt8]("TYER".utf8)
     ]
     private var identifiers: [ID3Version: [FrameType: [UInt8]]] = [
         .version2: [
@@ -120,7 +139,26 @@ class ID3FrameConfiguration {
         "TDES": .iTunesPodcastDescription,
         "TGID": .iTunesPodcastID,
         "TKWD": .iTunesPodcastKeywords,
-        "USLT": .unsyncronisedLyrics
+        "USLT": .unsyncronisedLyrics,
+        "TBPM": .beatsPerMinute,
+        "TDLY": .playlistDelay,
+        "TFLT": .fileType,
+        "TIME": .time,
+        "TKEY": .initialKey,
+        "TLAN": .languages,
+        "TLEN": .length,
+        "TMED": .mediaType,
+        "TOAL": .originalAlbumTitle,
+        "TOFN": .originalFilename,
+        "TOLY": .originalLyricists,
+        "TOPE": .originalArtists,
+        "TORY": .originalReleaseYear,
+        "TRDA": .recordingDate,
+        "TRSN": .internetRadioStationName,
+        "TRSO": .internetRadioStationOwner,
+        "TSIZ": .size,
+        "TSRC": .internationalStandardRecordingCode,
+        "TYER": .year,
     ]
     private var nameForIdentifier: [ID3Version: [String: FrameType]] = [
         .version2: [

--- a/Source/Frame/ID3FrameConfiguration.swift
+++ b/Source/Frame/ID3FrameConfiguration.swift
@@ -158,7 +158,7 @@ class ID3FrameConfiguration {
         "TRSO": .internetRadioStationOwner,
         "TSIZ": .size,
         "TSRC": .internationalStandardRecordingCode,
-        "TYER": .year,
+        "TYER": .year
     ]
     private var nameForIdentifier: [ID3Version: [String: FrameType]] = [
         .version2: [


### PR DESCRIPTION
*Provide a general summary of your changes*
Add all the missing frames contained in 4.2. Text information frames of the ID3 standard.

## Description
All the frame contained in the section quoted above have the same structure of the basic title/subtitle etc. frame. All this frame are implemented using ID3FrameWithStringContent.

> add frame identifiers configuration
> add parsing and creator classes for each frame

## Motivation and Context
*Why is this change required? What problem does it solve? If it fixes an open issue, please link to the issue here.*
#50 


## How Has This Been Tested?
Unit test and CI

## Types of changes
- [x] Enhancement

## Checklist:
- [x] My code follows the code style of this project :beers:.
- [x] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/chicio/ID3TagEditor/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [x] I have added tests to cover my changes :tada:.
- [x] All new and existing tests passed :white_check_mark:.
