### PR TITLE
Wire up iTunesGrouping to the ID3TagContentReader

### DIFF
--- a/Source/Tag/ID3TagContentReader.swift
+++ b/Source/Tag/ID3TagContentReader.swift
@@ -419,6 +419,15 @@ public class ID3TagContentReader {
     }
 
     /**
+      Read the itunes grouping frame content.
+     
+      - returns: the itunes grouping as `String`, or null.
+     */
+    public func iTunesGrouping() -> String? {
+        return (id3Tag.frames[.iTunesGrouping] as? ID3FrameWithStringContent)?.content
+    }
+
+    /**
       Read the itunes movement name frame content.
      
       - returns: the itunes movement name as `String`, or null.


### PR DESCRIPTION
The frame key was already defined, there just wasn't a convenience method exposed on ID3TagContentReader.

*Provide a general summary of your changes*

## Types of changes
- [ ] Bug fix :bug: (non-breaking change which fixes an issue)
- [x] New feature :sparkles: (non-breaking change which adds functionality)
- [ ] Breaking change :boom: (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project :beers:.
- [x] I have read the [CONTRIBUTING](https://github.com/chicio/ID3TagEditor/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [ ] I have added tests to cover my changes :tada:.
- [ ] All new and existing tests passed :white_check_mark:.
