### PR TITLE
Fix an out of bounds crash

### DIFF
--- a/Source/Parse/ID3TagVersionParser.swift
+++ b/Source/Parse/ID3TagVersionParser.swift
@@ -19,6 +19,8 @@ class ID3TagVersionParser: TagVersionParser {
     }
 
     private func tryToGetVersionFrom(mp3: Data) -> ID3Version? {
+        guard mp3.count > versionBytesOffset else { return nil }
+
         let version = [UInt8](mp3)[versionBytesOffset]
         return ID3Version(rawValue: version)
     }

--- a/Tests/Parse/ID3TagVersionParserTest.swift
+++ b/Tests/Parse/ID3TagVersionParserTest.swift
@@ -25,6 +25,11 @@ class ID3TagVersionParserTest: XCTestCase {
         XCTAssertEqual(.version3, id3VersionParser.parse(mp3: mp3WithV2Tag))
     }
 
+    func testShortData() throws {
+        let shortData = Data(capacity: 2)
+        XCTAssertEqual(.version3, id3VersionParser.parse(mp3: shortData))
+    }
+
     func testDefaultVersion() throws {
         let mp3WithV2Tag = try Data(
             contentsOf: URL(fileURLWithPath: PathLoader().pathFor(name: "example-to-be-modified", fileType: "mp3"))


### PR DESCRIPTION
## Description
* When parsing version bytes and the index is out of bounds a crash would occur

## Motivation and Context
Fixes a crash

## How Has This Been Tested?
Tested with a broken file that was crashing the app

## Types of changes
- [x] Bug fix :bug: (non-breaking change which fixes an issue)
- [ ] New feature :sparkles: (non-breaking change which adds functionality)
- [ ] Breaking change :boom: (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project :beers:.
- [ ] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/chicio/ID3TagEditor/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [x] I have added tests to cover my changes :tada:.
- [x] All new and existing tests passed :white_check_mark:.
