### PR TITLE
ID3FrameStringContentParser crash fix

### DIFF
--- a/Source/Parse/ID3FrameStringContentParser.swift
+++ b/Source/Parse/ID3FrameStringContentParser.swift
@@ -23,6 +23,9 @@ class ID3FrameStringContentParser {
     func parse(frame: Data, version: ID3Version) -> String? {
         let headerSize = id3FrameConfiguration.headerSizeFor(version: version)
         let frameContentRangeStart = headerSize + id3FrameConfiguration.encodingSize()
+        
+        guard frameContentRangeStart < frame.count else { return nil }
+        
         let frameContent = frame.subdata(in: frameContentRangeStart..<frame.count)
         let encoding = stringEncodingDetector.detect(frame: frame, version: version)
         if let frameContentAsString = String(data: frameContent, encoding: encoding) {

--- a/Tests/Parse/ID3StringContentParsingOperationTest.swift
+++ b/Tests/Parse/ID3StringContentParsingOperationTest.swift
@@ -17,6 +17,11 @@ class ID3StringContentParsingOperationTest: XCTestCase {
         paddingRemover: PaddingRemoverUsingTrimming(),
         id3FrameConfiguration: ID3FrameConfiguration()
     )
+    
+    func testTooSmallDataValue() {
+        let value = stringContentParser.parse(frame: Data(capacity: 1), version: .version3)
+        XCTAssertNil(value)
+    }
 
     func testFrameContentParsedV2() {
         let expectation = XCTestExpectation(description: "content without padding")


### PR DESCRIPTION
Fixes ID3FrameStringContentParser crash with invalid range

## Description
Added a guard before data is accessed.

## Motivation and Context
Some of my mp3 files are running into this crash.

## How Has This Been Tested?
Added a unit test.

## Types of changes
- [x] Bug fix :bug: (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project :beers:.
- [x] I have read the [CONTRIBUTING](https://github.com/chicio/ID3TagEditor/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [x] I have added tests to cover my changes :tada:.
- [x] All new and existing tests passed :white_check_mark:.
